### PR TITLE
Parameterize zfs_auto_snapshot class

### DIFF
--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,17 +1,22 @@
-class zfs_auto_snapshot::cron {
+class zfs_auto_snapshot::cron(
+  $hourly_snaps,      # Number of hourly snapshots to keep
+  $daily_snaps,       # Number of daily snapshots to keep
+  $weekly_snaps,      # Number of weekly snapshots to keep
+  $pool_names,        # List of pools to snapshot
+) {
   cron { 'zfssnap_hourly': 
-    command  => "/usr/sbin/zfs-auto-snapshot --syslog --label hourly --keep $zfs_auto_snapshot::params::hourly_snaps --recursive $zfs_auto_snapshot::params::$fsname",
+    command  => "/usr/sbin/zfs-auto-snapshot --syslog --label hourly --keep $hourly_snaps --recursive $pool_names",
     user     => 'root',
     minute   => 0,
   }
   cron { 'zfssnap_daily': 
-    command  => "/usr/sbin/zfs-auto-snapshot --syslog --label daily --keep $zfs_auto_snapshot::params::daily_snaps --recursive $zfs_auto_snapshot::params::$fsname",
+    command  => "/usr/sbin/zfs-auto-snapshot --syslog --label daily --keep $daily_snaps --recursive $pool_names",
     user     => 'root',
     minute   => 0,
     hour     => 0,
   }
   cron { 'zfssnap_weekly': 
-    command => "/usr/sbin/zfs-auto-snapshot --syslog --label weekly --keep $zfs_auto_snapshot::params::weekly_snaps --recursive $zfs_auto_snapshot::params::$fsname",
+    command => "/usr/sbin/zfs-auto-snapshot --syslog --label weekly --keep $weekly_snaps --recursive $pool_names",
     user    => 'root',
     minute  => 0,
     hour    => 0,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,20 @@
-class zfs_auto_snapshot($pool_names) {
-  include zfs_auto_snapshot::cron
-# Installs to /usr/local/sbin.
-  file { '/usr/local' :
-    ensure => directory,
-    owner => 'root', group => 'root', mode => 0755,
+class zfs_auto_snapshot(
+  $hourly_snaps = $zfs_auto_snapshot::params::hourly_snaps,
+  $daily_snaps  = $zfs_auto_snapshot::params::daily_snaps,
+  $weekly_snaps = $zfs_auto_snapshot::params::weekly_snaps,
+  $pool_names   = $zfs_auto_snapshot::params::pool_names,
+)
+inherits zfs_auto_snapshot::params {
+
+  class {'zfs_auto_snapshot::cron':
+    hourly_snaps => $hourly_snaps,
+    daily_snaps  => $daily_snaps,
+    weekly_snaps => $weekly_snaps,
+    pool_names   => $pool_names,
   }
-  file { '/usr/local/sbin' :
-    ensure => directory,
-    owner => 'root', group => 'root', mode => 0755,
-  }
+
+  # Installs to /usr/local/sbin.which we can assume exists as per the Filesystem Hierachy Standard
+
   file { '/usr/local/sbin/zfs-auto-snapshot' :
     ensure => present,
     source => "puppet:///modules/${module_name}/zfs-auto-snapshot.pl",

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,8 @@
-class zfs-auto-snapshot::params {
+class zfs_auto_snapshot::params {
 
 # Filesystem to snapshot:
 # Default (specific to some MSU systems)
-  $fsname = $pool_names
+  $pool_names = [ 'localpool' ]
 
 # Number of snapshots:
 # Number of hourly snaps to keep:


### PR DESCRIPTION
These patches parameterize the zfs_auto_snapshot class, so that the pool name can be specified as an argument.

This is useful for our purposes, since we import all modules with git submodules, therefore having configuration inside modules is not ideal.
