### PR TITLE
Set absolute path of z{fs,pool}.

### DIFF
--- a/files/zfs-auto-snapshot.pl
+++ b/files/zfs-auto-snapshot.pl
@@ -19,8 +19,8 @@
 # Place, Suite 330, Boston, MA  02111-1307  USA
 #
 
-our $ZFS="zfs";
-our $ZPOOL="zpool";
+our $ZFS="/sbin/zfs";
+our $ZPOOL="/sbin/zpool";
 
 use Getopt::Long;
 


### PR DESCRIPTION
We cannot rely on them being in $PATH, especially as they're running as
a cron job, which only have /{,usr/}bin in $PATH on Ubuntu.
